### PR TITLE
Add 'persistent_data_handler' to the allowed keys

### DIFF
--- a/src/FacebookFactory.php
+++ b/src/FacebookFactory.php
@@ -56,7 +56,7 @@ class FacebookFactory
             }
         }
 
-        $keys = ['app_id', 'app_secret', 'default_graph_version', 'default_access_token'];
+        $keys = ['app_id', 'app_secret', 'default_graph_version', 'default_access_token', 'persistent_data_handler' ];
 
         return array_only($config, $keys);
     }

--- a/src/FacebookFactory.php
+++ b/src/FacebookFactory.php
@@ -56,7 +56,7 @@ class FacebookFactory
             }
         }
 
-        $keys = ['app_id', 'app_secret', 'default_graph_version', 'default_access_token', 'persistent_data_handler' ];
+        $keys = ['app_id', 'app_secret', 'default_graph_version', 'default_access_token', 'persistent_data_handler'];
 
         return array_only($config, $keys);
     }


### PR DESCRIPTION
Without it, user will not be able to change the session handler in /config/facebook.php , needed to do a working 'facebook log-in'